### PR TITLE
Changing reference of 'sunspot-rails'

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ gem "escape"
 gem 'will_paginate', '3.0.pre2'
 gem "paperclip"
 gem "acts-as-taggable-on", ">=2.0.6"
-gem "sunspot_rails", "1.2.rc4"
+gem "sunspot", "1.2.rc4", :git => "https://github.com/outoftime/sunspot.git", :tag => "v1.2.rc4"
 gem "mysql2", "0.2.7"
 gem "devise", "1.3.4"
 gem "stringex"


### PR DESCRIPTION
Bundler fails since it fails to find 'sunspot-rails'.
I figured the repository has been renamed as 'sunspot'.
Pushing a new Gemfile which references to valid paths of 'sunspot'
